### PR TITLE
Update __init__.py

### DIFF
--- a/jvc_projector/__init__.py
+++ b/jvc_projector/__init__.py
@@ -175,9 +175,9 @@ class JVCProjector:
 
     def power_state(self):
         message = self._send_command(Commands.power_status.value, ack=ACKs.power_ack.value)
-        return PowerStates(message).name
+        return PowerStates(message)
 
     def is_on(self):
-        on = [PowerStates.lamp_on.name, PowerStates.reserved.name]
+        on = [PowerStates.lamp_on, PowerStates.reserved]
         return self.power_state() in on
 


### PR DESCRIPTION
Fixed bug where is_on() returned False whenever the projector was in a state of PowerStates.lamp_on or PowerStates.reserved.